### PR TITLE
Set AXES_WIDTH and AXES_HEIGHT using environment variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,11 +142,11 @@ You can find more examples and their outputs in the `examples` folder.
 
 ### mpl_ascii.AXES_WIDTH
 
-Adjust the width of each axis according to the number of characters. The final width of the image might extend a few characters beyond this, depending on the size of the ticks and axis labels. Default is `150`.
+Adjust the width of each axis according to the number of characters. The library first looks for the `AXES_WIDTH` as an environment variable. This can then be overwritten in the Python program by setting `mpl_ascii.AXES_WIDTH`. The final width of the image might extend a few characters beyond this, depending on the size of the ticks and axis labels. Default is `150`.
 
 ### mpl_ascii.AXES_HEIGHT
 
-Adjust the height of each axis according to the number of characters. The final height of the image might extend a few characters beyond this, depending on the size of the ticks and axis labels. Default is `40`
+Adjust the height of each axis according to the number of characters. The library first looks for the `AXES_HEIGHT` as an environment variable. This can then be overwritten in the Python program by setting `mpl_ascii.AXES_HEIGHT`. The final height of the image might extend a few characters beyond this, depending on the size of the ticks and axis labels. Default is `40`.
 
 ### mpl_ascii.ENABLE_COLORS
 

--- a/mpl_ascii/__init__.py
+++ b/mpl_ascii/__init__.py
@@ -1,5 +1,5 @@
+import os
 from typing import Optional
-from matplotlib._pylab_helpers import Gcf
 
 from matplotlib.backends.backend_agg import (
     FigureManagerBase,
@@ -8,13 +8,14 @@ from matplotlib.backends.backend_agg import (
 from matplotlib.figure import Figure
 
 from mpl_ascii.ascii_canvas import AsciiCanvas
-from mpl_ascii.ax import AxesPlot, draw_ax, get_plots
+from mpl_ascii.ax import AxesPlot
 from mpl_ascii.color_map import FigureColorMap
 
 from rich.console import Console
 
-AXES_WIDTH = 150
-AXES_HEIGHT = 40
+AXES_HEIGHT = int(os.getenv("AXES_HEIGHT", 40))
+AXES_WIDTH = int(os.getenv("AXES_WIDTH", 150))
+
 ENABLE_COLORS = True
 
 UNRELEASED = False


### PR DESCRIPTION
This addresses issue https://github.com/chriscave/mpl_ascii/issues/7

Now AXES_WIDTH and AXES_HEIGHT are set by environment variables if they exist and can be overwritten in the python program. If they don't exist then it's the same behaviour as before.